### PR TITLE
Update to support latest amex interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 function main() {
-  const WAIT_TIME_MS = 2000;
-  const offerButtons = document.getElementsByClassName('selectbtn');
-  for (let i = 0; i < offerButtons.length; ++i) {
-    setTimeout(() => {
-      try {
-        console.log('Clicking ' + offerButtons[i].id);
-        offerButtons[i].click();
-      } catch (e) {
-        console.error(e);
-      }
-    }, i * WAIT_TIME_MS)
-  }
+	const WAIT_TIME_MS = 5000;
+	const offerButtons = document.getElementsByClassName('btn');
+	for (let i = 0; i < offerButtons.length; ++i) {
+		if (offerButtons[i].title == "Add to Card") {
+			setTimeout(() => {
+				try {
+					console.log('Clicking ' + offerButtons[i].id);
+					offerButtons[i].click();
+				} catch (e) {
+					console.error(e);
+				}
+			}, i * WAIT_TIME_MS)
+		}
+	}
 };
 
 main();


### PR DESCRIPTION
Just changed from 'selectbtn' to 'btn', as Amex is no longer using 'selectbtn' on their interface. This should capture all buttons. Then I just filter on ones with title 'Add to Card' to eliminate the 'Enroll Now', 'Add Someone', 'Learn More' type buttons which take you to another page instead of enrolling you in an offer.