### PR TITLE
Update to select "Add to Card" buttons after website update

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function main() {
 	const WAIT_TIME_MS = 2000;
-	const offerButtons = document.querySelectorAll('button.btn.offer-cta');
+	const offerButtons = document.querySelectorAll('button.offer-cta[title="Add to Card"]');
 	for (let i = 0; i < offerButtons.length; ++i) {
 		setTimeout(() => {
 			try {


### PR DESCRIPTION
All buttons on the page (for "Add to Card" offers and others that navigate to a new page) now share an "offer-cta" class, and must be distinguished by button title to avoid navigating to a new page in the middle of the list.